### PR TITLE
feat: add scroll-to-top button with smooth scroll and visibility on s…

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -11,6 +11,7 @@ import {
   CheckCircle2,
 } from "lucide-react";
 import HeroSection from "@/components/hero";
+import ScrollToTop from "@/components/ScrollToTop";
 import {
   Accordion,
   AccordionContent,
@@ -208,6 +209,9 @@ export default function LandingPage() {
           </div>
         </div>
       </section>
+
+      {/* Scroll To Top Button */}
+      <ScrollToTop />
     </>
   );
 }

--- a/components/ScrollToTop.jsx
+++ b/components/ScrollToTop.jsx
@@ -1,0 +1,35 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import { ArrowUp } from "lucide-react";
+
+const ScrollToTop = () => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  const toggleVisibility = () => {
+    setIsVisible(window.scrollY > 200);
+  };
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  useEffect(() => {
+    window.addEventListener("scroll", toggleVisibility);
+    return () => window.removeEventListener("scroll", toggleVisibility);
+  }, []);
+
+  return (
+    isVisible && (
+      <button
+        onClick={scrollToTop}
+        className="fixed bottom-6 right-6 z-50 p-3 rounded-full bg-primary text-black shadow-lg hover:bg-primary/90 transition-colors"
+        aria-label="Scroll to top"
+      >
+        <ArrowUp className="h-5 w-5" />
+      </button>
+    )
+  );
+};
+
+export default ScrollToTop;


### PR DESCRIPTION
# 📝 Pull Request Description

## 📌 Title  
**PR Title:** `feat: add scroll-to-top button with smooth scroll and visibility on scroll`

Fix: #5 

Before: 

https://github.com/user-attachments/assets/c7f344a8-ab02-48b1-af5e-794ccc86adc3

After: 

https://github.com/user-attachments/assets/77c3c5c7-9998-406c-b16b-6f4c0e5f5168


---

## 🛠️ What does this PR do?

- Adds a floating scroll-to-top button that appears after scrolling down 200px  
- Enables smooth scroll to the top of the page on click  
- Uses Tailwind CSS for styling (fixed position, hover effect, black arrow icon)  
- Enhances overall user experience on long pages

---

## 🔍 Related Issues  
**Closes:**  
**Related to:** #UX-enhancement (if applicable)

---

## 💡 Type of Change  

- [x] New feature  
- [ ] Code refactor  
- [ ] Bug fix  
- [ ] Documentation update  
- [ ] Test improvement  
- [ ] CI/CD improvement  
- [ ] Other:

---

## 🧪 How to Test

1. Run the app and scroll down beyond 200px  
2. Confirm that the scroll-to-top button appears  
3. Click the button and verify smooth scroll to top  
4. Ensure button styles render correctly with a black icon  
5. Confirm no console errors or layout issues occur

---

## ✅ Checklist  

- [x] Code compiles without errors  
- [x] Linting passes  
- [ ] All tests pass (if any)  
- [x] I’ve added/updated necessary documentation (if applicable)  
- [x] PR follows the project’s code style and guidelines  

---

## 🗒️ Additional Notes  

- The button is added to the main landing page (`page.js`)  
- Icon uses Lucide's `<ArrowUp />` with black color  
- Component is modular and can be reused across pages if needed
