### PR TITLE
Fix: Scrollup Icon button Arrow not visible in Light Mode

### DIFF
--- a/components/ScrollToTop.jsx
+++ b/components/ScrollToTop.jsx
@@ -1,10 +1,13 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import { useTheme } from 'next-themes';
 import { ArrowUp } from "lucide-react";
 
 const ScrollToTop = () => {
   const [isVisible, setIsVisible] = useState(false);
+  const { theme } = useTheme();
+  const iconColor = theme === 'dark' ? 'white' : 'black';
 
   const toggleVisibility = () => {
     setIsVisible(window.scrollY > 200);
@@ -26,7 +29,7 @@ const ScrollToTop = () => {
         className="fixed bottom-6 right-6 z-50 p-3 rounded-full bg-primary text-black shadow-lg hover:bg-primary/90 transition-colors"
         aria-label="Scroll to top"
       >
-        <ArrowUp className="h-5 w-5" />
+        <ArrowUp color={iconColor} className="h-5 w-5" />
       </button>
     )
   );


### PR DESCRIPTION
Fixes issue: #70 

💬 PR Description:
This PR resolves a visibility issue with the Scrollup button.
Previously, the button’s background color switched correctly on theme change, but the arrow icon (ArrowUp) remained black regardless of the theme, making it invisible in light mode.

🔧 Changes made:
Integrated useTheme from next-themes in ScrollToTop component.
Dynamically set the arrow icon color to:
white in dark mode
black in light mode

🧪 Result:
The arrow icon now remains clearly visible in both dark and light themes, enhancing accessibility and UI consistency.

![Screenshot 2025-06-18 120405](https://github.com/user-attachments/assets/39e5d486-442f-484e-9c47-b9fc11802799)

Let me know if any changes are need.